### PR TITLE
Strip out unnecessary React checks on production build

### DIFF
--- a/webpack-production.config.js
+++ b/webpack-production.config.js
@@ -14,6 +14,12 @@ const config = {
     filename: 'app.js', // Name of output file
   },
   plugins: [
+    // Define production build to allow React to strip out unnecessary checks
+    new webpack.DefinePlugin({
+      'process.env':{
+        'NODE_ENV': JSON.stringify('production')
+      }
+    }),
     // Minify the bundle
     new webpack.optimize.UglifyJsPlugin({
       compress: {


### PR DESCRIPTION
Prevents the following warning when running the static page generated by `npm run build`

    warning.js:44Warning: It looks like you're using a minified copy of the development build of React. When deploying React apps to production, make sure to use the production build which skips development warnings and is faster. See https://fb.me/react-minification for more details.