### PR TITLE
Adding Link for Online Demo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is an example project that uses [Material-UI](https://github.com/callemall/material-ui).
 
+Online Demo can be seen here - [webpack-material-ui-example.surge.sh/](http://webpack-material-ui-example.surge.sh/)
+
 ## Installation
 
 After cloning the repository, install dependencies:


### PR DESCRIPTION
Everytime i came to view this example project, I wondered how does the example project look like and what it has. Adding a link to the demo will help. 

Adding a PR for same. 

Project is hosted on surge at - http://webpack-material-ui-example.surge.sh/